### PR TITLE
form 제출 시 이메일 전송 안 되는 오류 해결

### DIFF
--- a/src/app/member/_components/JoinForm.tsx
+++ b/src/app/member/_components/JoinForm.tsx
@@ -60,6 +60,7 @@ const JoinForm = ({
           onChange={onChange}
           disabled={verified}
         />
+        {verified && <input type="hidden" name="email" value={form.email} />}
         <button type="button" onClick={sendCode} disabled={verified}>
           {verified ? '인증완료' : '코드발송'}
         </button>


### PR DESCRIPTION
## ✅ PR 타입
<!-- 해당하는 항목 하나 이상 선택하세요 -->
- [ ] Feat      : 새로운 기능 추가
- [x] Fix       : 버그 수정
- [ ] Update    : 기존 기능 수정 (기획 변경·개선)
- [ ] Refactor  : 코드 리팩토링 (기능 변경 없음)
- [ ] Perf      : 성능 개선 (더 효율적인 코드로 수정)
- [ ] Docs      : 문서 수정
- [ ] Chore     : 빌드, 설정, 기타 잡일 변경
- [ ] Test      : 테스트 코드 추가/수정


## 📌 개요
<!-- PR의 목적, 배경을 간단히 설명 -->
<!--
예) 회원가입 API를 추가하여 신규 회원 데이터를 DB에 저장할 수 있도록 구현했습니다.
-->

회원가입 시 이메일을 적고 인증까지 했는데, 회원가입이 완료되지 않는 문제를 해결했습니다.

---

## 🔍 변경 사항
<!-- 주요 변경 사항 목록화 -->
<!--
- 예) POST `/api/members` 엔드포인트 구현
- 예) 요청 Body 유효성 검증 추가
- 예) 비밀번호 암호화 로직 적용(BCrypt)
- 예) 회원가입 성공 시 JWT 발급
-->

문제 원인: 인증 완료 시 이메일 input 태그가 disabled 되면서, 폼 제출할 때 이메일 input 태그에 들어가는 이메일 값이 전송이 안 되고 있었음.

해결: hidden input 태그를 추가해서, 인증이 완료된 상태(verifyCode=true)면 해당 태그를 통해서 이메일을 폼에 포함시킴.

---

## 📸 스크린샷(선택)
<!-- UI 변경이 있다면 Before/After 이미지 첨부 -->

---

## 💬 기타 참고 사항
<!-- 리뷰어가 알아야 할 내용, 추후 작업 계획 등 -->
- disabled된 이메일 칸은 회색으로 보이도록 해야 함.
- 칸 사이 텀이 일정하지 않음.